### PR TITLE
[#10] 스프링 헬름 패키지 환경변수 활용 변경

### DIFF
--- a/helm/spring/Chart.yaml
+++ b/helm/spring/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spring
 description: A Helm chart for EarSEO Spring
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"

--- a/helm/spring/templates/configmap.yaml
+++ b/helm/spring/templates/configmap.yaml
@@ -5,6 +5,5 @@ metadata:
   labels:
     app: {{ .Values.name }}
 data:
-  application-config.yaml: |
-{{ .Values.config | nindent 4 }}
+{{- toYaml .Values.env | nindent 2 }}
 ---

--- a/helm/spring/templates/deployment.yaml
+++ b/helm/spring/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.profile }}
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             {{- if .Values.kafkaUser.enabled }}
             - name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
               valueFrom:

--- a/helm/spring/templates/deployment.yaml
+++ b/helm/spring/templates/deployment.yaml
@@ -33,14 +33,25 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: {{ .Values.profile }}
+            {{- if .Values.kafkaUser.enabled }}
+            - name: SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.kafkaUser.secretName }}
+                  name: {{ .Values.kafkaUser.secretName }}
+                  {{- else }}
+                  name: {{ .Values.name }}-kafka-user
+                  {{- end }}
+                  key: sasl.jaas.config
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.name }}-config
           ports:
             - containerPort: 8080
               protocol: TCP
               name: http
           volumeMounts:
-            - mountPath: /etc/config
-              name: configmap
-              readOnly: true
             - mountPath: /etc/secret
               name: secret
               readOnly: true
@@ -61,12 +72,6 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
       volumes:
-        - name: configmap
-          configMap:
-            name: {{ .Values.name }}-config
-            items:
-              - key: application-config.yaml
-                path: application-config.yaml
         - name: secret
           secret:
             secretName: {{ .Values.name }}-secret

--- a/helm/spring/values.yaml
+++ b/helm/spring/values.yaml
@@ -53,10 +53,15 @@ monitor:
   service:
     interval: 10s
 
-# Configmap
-config: |
-  server:
-    port: 8080
+# Configmap (환경변수)
+env:
+  EXAMPLE_ENV: empty_value
 
+# Secret (yaml 마운트)
 secret: |
   secret: i-am-secret
+
+# KafkaUser
+kafkaUser:
+  enabled: false
+  secretName: "" # 필요시 오버라이드

--- a/k8s-manifests/middleware/kafka/resources/kafka-topic.yaml
+++ b/k8s-manifests/middleware/kafka/resources/kafka-topic.yaml
@@ -1,0 +1,53 @@
+# Kafka Topic 생성
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: member-level
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    strimzi.io/cluster: kafka-earseo-cluster
+spec:
+  # 파티션 설정
+  partitions: 1
+  # 레플리카 설정 (1 master, 2 slave)
+  replicas: 3
+  config:
+    # 메시지 보관 기간 (1 day)
+    retention.ms: 86400000
+    # 세그먼트 파일 크기 100MB
+    segment.bytes: 104857600
+    # 2개 이상의 레플리카에 저장되어야 저장 성공
+    min.insync.replicas: 2
+    # Zstandard 압축
+    compression.type: zstd
+    # 오래된 메시지 삭제 정책
+    cleanup.policy: delete
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: story-test
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    strimzi.io/cluster: kafka-earseo-cluster
+spec:
+  # 파티션 설정
+  partitions: 1
+  # 레플리카 설정 (1 master, 2 slave)
+  replicas: 3
+  config:
+    # 메시지 보관 기간 (1 day)
+    retention.ms: 86400000
+    # 세그먼트 파일 크기 100MB
+    segment.bytes: 104857600
+    # 2개 이상의 레플리카에 저장되어야 저장 성공
+    min.insync.replicas: 2
+    # Zstandard 압축
+    compression.type: zstd
+    # 오래된 메시지 삭제 정책
+    cleanup.policy: delete
+---

--- a/k8s-manifests/middleware/kafka/resources/kafka-user-secret-syncer.yaml
+++ b/k8s-manifests/middleware/kafka/resources/kafka-user-secret-syncer.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kafka-user-secret-syncer
+  namespace: backend
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kafka-user-secret-syncer-role
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+rules:
+  - verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+    apiGroups: [""]
+    resources: ["secrets"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kafka-user-secret-syncer-backend
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+subjects:
+  - kind: ServiceAccount
+    name: kafka-user-secret-syncer
+    namespace: backend
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kafka-user-secret-syncer-role
+---
+# Kafka User Secret backend 네임스페이스로 이동
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sync-kafka-user-secret
+  namespace: backend
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      serviceAccountName: kafka-user-secret-syncer
+      restartPolicy: OnFailure
+      containers:
+        - name: cluster-init
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              
+              # KafkaUser 등록으로 같이 생성된 KafkaUser Secret 
+              SECRETS=(
+                "backend-core-kafka-user:kafka:backend"
+                "backend-story-kafka-user:kafka:backend"
+              )
+          
+              for secret_info in "${SECRETS[@]}"; do
+                IFS=':' read -r secret_name src_ns dst_ns <<< "$secret_info"
+          
+                echo "Syncing $secret_name from $src_ns to $dst_ns..."
+          
+                kubectl get secret "$secret_name" -n "$src_ns" -o yaml \
+                  | grep -v '^\s*namespace:\s' \
+                  | kubectl apply -n "$dst_ns" -f -
+              done

--- a/k8s-manifests/middleware/kafka/resources/kafka-user.yaml
+++ b/k8s-manifests/middleware/kafka/resources/kafka-user.yaml
@@ -1,0 +1,88 @@
+# Kafka User 생성 (SASL_PLAINTEXT 인증)
+# KafkaUser의 이름은 ${서비스 레포지토리명}-kafka-user 패턴이어야함
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: backend-core-kafka-user
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    strimzi.io/cluster: kafka-earseo-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # core 토픽 읽기 권한
+      - resource:
+          type: topic
+          name: "core-"
+          patternType: prefix
+        operations:
+          - Read
+          - Write
+          - Describe
+          - DescribeConfigs
+      # sight 토픽 쓰기권한
+      - resource:
+          type: topic
+          name: "sight-"
+          patternType: prefix
+        operations:
+          - Write
+          - Describe
+          - DescribeConfigs
+      # backend-core 컨슈머 그룹 읽기권한
+      - resource:
+          type: group
+          name: "backend-core-consumer-group"
+          patternType: literal
+        operations:
+          - Read
+          - Describe
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaUser
+metadata:
+  name: backend-story-kafka-user
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  labels:
+    strimzi.io/cluster: kafka-earseo-cluster
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      # story 토픽 읽기 권한
+      - resource:
+          type: topic
+          name: "story-"
+          patternType: prefix
+        operations:
+          - Read
+          - Write
+          - Describe
+          - DescribeConfigs
+      # member 토픽 쓰기권한
+      - resource:
+          type: topic
+          name: "member-"
+          patternType: prefix
+        operations:
+          - Write
+          - Describe
+          - DescribeConfigs
+      # backend-story 컨슈머 그룹 읽기권한
+      - resource:
+          type: group
+          name: "backend-story-consumer-group"
+          patternType: literal
+        operations:
+          - Read
+          - Describe
+---

--- a/k8s-manifests/middleware/postgres/postgres-manifests.yaml
+++ b/k8s-manifests/middleware/postgres/postgres-manifests.yaml
@@ -41,7 +41,7 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres
+  name: postgres-svc
   namespace: postgres
   annotations:
     argocd.argoproj.io/sync-wave: "0"
@@ -64,7 +64,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  serviceName: postgres
+  serviceName: postgres-svc
   replicas: 1
   selector:
     matchLabels:

--- a/k8s-manifests/monitoring/otel-collector.yaml
+++ b/k8s-manifests/monitoring/otel-collector.yaml
@@ -3,7 +3,7 @@ mode: daemonset
 image:
   repository: otel/opentelemetry-collector-contrib
   tag: 0.134.1
-
+hostNetwork: true
 clusterRole:
   create: true
   rules:

--- a/k8s-manifests/services/backend-core.yaml
+++ b/k8s-manifests/services/backend-core.yaml
@@ -4,3 +4,20 @@ image:
 replicaCount: 1
 service:
   type: NodePort
+kafkaUser:
+  enabled: true
+env:
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "dev"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/core"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "validate"
+  LOGGING_LEVEL_ORG_HIBERNATE_SQL: "debug"
+
+  SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"
+
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "kafka-earseo-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  SPRING_KAFKA_CONSUMER_GROUP_ID: "backend-core-consumer-group"
+  SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
+  SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: "SCRAM-SHA-512"

--- a/k8s-manifests/services/backend-member.yaml
+++ b/k8s-manifests/services/backend-member.yaml
@@ -11,7 +11,8 @@ env:
   SPRING_PROFILES_ACTIVE: "dev"
   SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/member"
   SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
-  SPRING_JPA_SHOW_SQL: "true"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "validate"
+  LOGGING_LEVEL_ORG_HIBERNATE_SQL: "debug"
 
   SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
   SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"

--- a/k8s-manifests/services/backend-member.yaml
+++ b/k8s-manifests/services/backend-member.yaml
@@ -4,3 +4,19 @@ image:
 replicaCount: 1
 service:
   type: NodePort
+kafkaUser:
+  enabled: false
+env:
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "dev"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/member"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_SHOW_SQL: "true"
+
+  SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"
+
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "kafka-earseo-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  SPRING_KAFKA_CONSUMER_GROUP_ID: "backend-member-consumer-group"
+  SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
+  SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: "SCRAM-SHA-512"

--- a/k8s-manifests/services/backend-route.yaml
+++ b/k8s-manifests/services/backend-route.yaml
@@ -4,3 +4,19 @@ image:
 replicaCount: 1
 service:
   type: NodePort
+kafkaUser:
+  enabled: false
+env:
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "dev"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/route"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_SHOW_SQL: "true"
+
+  SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"
+
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "kafka-earseo-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  SPRING_KAFKA_CONSUMER_GROUP_ID: "backend-route-consumer-group"
+  SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
+  SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: "SCRAM-SHA-512"

--- a/k8s-manifests/services/backend-route.yaml
+++ b/k8s-manifests/services/backend-route.yaml
@@ -11,7 +11,8 @@ env:
   SPRING_PROFILES_ACTIVE: "dev"
   SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/route"
   SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
-  SPRING_JPA_SHOW_SQL: "true"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "validate"
+  LOGGING_LEVEL_ORG_HIBERNATE_SQL: "debug"
 
   SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
   SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"

--- a/k8s-manifests/services/backend-sight.yaml
+++ b/k8s-manifests/services/backend-sight.yaml
@@ -11,7 +11,8 @@ env:
   SPRING_PROFILES_ACTIVE: "dev"
   SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/sight"
   SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
-  SPRING_JPA_SHOW_SQL: "true"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "validate"
+  LOGGING_LEVEL_ORG_HIBERNATE_SQL: "debug"
 
   SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
   SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"

--- a/k8s-manifests/services/backend-sight.yaml
+++ b/k8s-manifests/services/backend-sight.yaml
@@ -4,3 +4,19 @@ image:
 replicaCount: 1
 service:
   type: NodePort
+kafkaUser:
+  enabled: false
+env:
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "dev"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/sight"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_SHOW_SQL: "true"
+
+  SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"
+
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "kafka-earseo-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  SPRING_KAFKA_CONSUMER_GROUP_ID: "backend-sight-consumer-group"
+  SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
+  SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: "SCRAM-SHA-512"

--- a/k8s-manifests/services/backend-story.yaml
+++ b/k8s-manifests/services/backend-story.yaml
@@ -11,7 +11,8 @@ env:
   SPRING_PROFILES_ACTIVE: "dev"
   SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/story"
   SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
-  SPRING_JPA_SHOW_SQL: "true"
+  SPRING_JPA_HIBERNATE_DDL_AUTO: "validate"
+  LOGGING_LEVEL_ORG_HIBERNATE_SQL: "debug"
 
   SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
   SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"

--- a/k8s-manifests/services/backend-story.yaml
+++ b/k8s-manifests/services/backend-story.yaml
@@ -4,3 +4,19 @@ image:
 replicaCount: 1
 service:
   type: NodePort
+kafkaUser:
+  enabled: true
+env:
+  SERVER_PORT: "8080"
+  SPRING_PROFILES_ACTIVE: "dev"
+  SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres-svc.postgres.svc.cluster.local:5432/story"
+  SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+  SPRING_JPA_SHOW_SQL: "true"
+
+  SPRING_DATA_REDIS_SENTINEL_MASTER: "valkey-master"
+  SPRING_DATA_REDIS_SENTINEL_NODES: "valkey-sentinel.valkey.svc.cluster.local:26379"
+
+  SPRING_KAFKA_BOOTSTRAP_SERVERS: "kafka-earseo-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+  SPRING_KAFKA_CONSUMER_GROUP_ID: "backend-story-consumer-group"
+  SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
+  SPRING_KAFKA_PROPERTIES_SASL_MECHANISM: "SCRAM-SHA-512"

--- a/terraform/k8s/services.tf
+++ b/terraform/k8s/services.tf
@@ -65,7 +65,7 @@ locals {
             valueFiles = [
               "$service/k8s/helm-value.yaml",
               "$values/k8s-manifests/services/${app_name}.yaml",
-              "$secrets/k8s-secret-manifests/services/${app_name}.yaml"
+              "$secrets/services/${app_name}.yaml"
             ]
           }
         },
@@ -81,7 +81,7 @@ locals {
         },
         {
           repoURL        = "https://github.com/earseo/infra-secret-manifests.git"
-          targetRevision = "main"
+          targetRevision = "develop"
           ref            = "secrets"
         },
       ]


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 새로운 환경변수 활용 방식 적용 헬름 차트 작성
  - 환경변수 치환 방식 적용
  - KafkaUser 지원을 위한 SASL JAAS config 주입
- KafkaUser, KafkaTopic 사용방식 수정
  - 테스트를 위한 story, core KafkaUser, KafkaTopic 생성
  - KafkaUser 시크릿의 네임스페이스 이전을 위한 ServiceAccount 생성 및 argocd Hook Job 생성
- postgreSQL 서비스명 수정
- 환경변수 활용 방식 수정
  - 미들웨어 기본 환경변수 추가
  - PostgreSQL, Valkey 크레덴셜 추가
- 테라폼 backend applications 크레덴셜 헬름 벨류 깃헙 path 조정

---

## BREAKING CHANGE (옵션)
- Kafka 사용시 Topic을 유동적으로 생성하는 옵션을 제거해놓은 관계로 각 서버에서 카프카가 필요한 상황이 생긴다면 문의 부탁드립니다.
- 백엔드 레포지토리에서 dev 프로파일의 application.yaml을 ConfigMap와 Secret을 마운트해서 주입하던 방식에서 resources 디렉토리 내에 application-dev.yaml으로 백엔드 개발자분이 직접 작성하고 환경변수를 배포시에 주입하는 방식으로 전황하였습니다. (크레덴셜이 담겨있는 시크릿 리소스는 마운트 방식을 유지합니다)

---

## 참고
- 변경된 미들웨어 관련 환경변수와 application.yaml 관련 내용은 팀 노션에 작성되어있으니 참고 바랍니다.
  ```yaml
  config:
    import:
      - optional:file:/etc/secret/application-secret.yaml
  spring:
    datasource:
      driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.postgresql.Driver}
      url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/earseo}
      username: ${DB_USERNAME:postgres} # 시크릿 야믈 임포트에서 덮어씀
      password: ${DB_PASSWORD:1234} # 시크릿 야믈 임포트에서 덮어씀
    jpa:
      hibernate:
        ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
      properties:
        hibernate:
          show_sql: false # <- 사용 지양 (System.out으로 출력)
    kafka:
      bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
      consumer:
        group-id: ${SPRING_KAFKA_CONSUMER_GROUP_ID:${spring.application.name}-consumer-group}
        auto-offset-reset: earliest
        key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
        value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
      producer:
        key-serializer: org.apache.kafka.common.serialization.StringSerializer
        value-serializer: org.apache.kafka.common.serialization.StringSerializer
        acks: all
      properties:
        security.protocol: ${SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL:PLAINTEXT}
        sasl.mechanism: ${SPRING_KAFKA_PROPERTIES_SASL_MECHANISM:PLAIN}
        sasl.jaas.config: ${SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG:}
    data:
      redis:
        password: ${VALKEY_PASSWORD:} # 시크릿 야믈 마운트로 덮어씀
        sentinel:
          master: ${SPRING_DATA_REDIS_SENTINEL_MASTER:valkey-master}
          nodes: ${SPRING_DATA_REDIS_SENTINEL_NODES:localhost:26379}
  logging:
    level:
      org.hibernate.SQL: ${LOGGING_LEVEL_ORG_HIBERNATE_SQL:debug} # 로그 사용 (logger를 통해 출력)
  ```

closes #10